### PR TITLE
add handle_methods & authorize to Auth object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 coverage/*
 .nyc_output
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 coverage/*
 .nyc_output
 .idea/
+**/*.iml

--- a/lib/session.js
+++ b/lib/session.js
@@ -64,6 +64,10 @@ function Session (gate, sender, sessionId) {
         sTrace.set(id, actor);
     };
 
+    this.getTrace = function(id) {
+        return sTrace.get(id);
+    };
+
     this.removeTrace = function(engine, id) {
         let actor = false;
         if (sTrace.has(id)){
@@ -91,6 +95,10 @@ function Session (gate, sender, sessionId) {
     this.addSub = function(id, subD)
     {
         sSub.set(id, subD);
+    };
+
+    this.getSub = function(id) {
+        return sSub.get(id);
     };
 
     this.removeSub = function(engine, id) {

--- a/lib/wamp/gate.js
+++ b/lib/wamp/gate.js
@@ -98,9 +98,19 @@ class WampHandler extends BaseGate {
 
     hello(session, realmName, details) {
         session.realmName = realmName;
-        if (this.isAuthRequired()) {
+        if (this.isAuthRequired() && typeof this._authHandler.authenticate === "function") {
             session.secureDetails = details;
-            if (details.hasOwnProperty('authmethods') && details.authmethods.indexOf('ticket') >= 0) {
+            if (typeof this._authHandler.handle_methods === "function") {
+                this._authHandler.handle_methods(session.realmName, session.secureDetails, function (err, method, extra) {
+                    if (err) {
+                        this.sendAbort(session, "wamp.error.authorization_failed");
+                    }
+                    else {
+                        this.sendChallenge(session, method, extra || {});
+                    }
+                }.bind(this));
+            }
+            else if (details.hasOwnProperty('authmethods') && details.authmethods.indexOf('ticket') >= 0) {
                 this.sendChallenge(session, 'ticket', {});
             }
             else {
@@ -118,20 +128,25 @@ class WampHandler extends BaseGate {
     }
 
     authenticate(session, secret) {
-        this._authHandler.authenticate(session.realmName, session.secureDetails, secret, function (err) {
-            if (err) {
-                this.sendAbort(session, "wamp.error.authorization_failed");
-            }
-            else {
-                this.getRouter().getRealm(session.realmName, function (realm) {
-                    realm.joinSession(session);
-                    var details = this.getRealmDetails(session.realmName);
-                    details.authid = session.secureDetails.authid;
-                    details.authmethod = "ticket";
-                    this.sendWelcome(session, details);
-                }.bind(this));
-            }
-        }.bind(this));
+        if (!this.isAuthRequired() || typeof this._authHandler.authenticate !== "function") {
+            this.sendAbort(session, "wamp.error.authorization_failed");
+        }
+        else {
+            this._authHandler.authenticate(session.realmName, session.secureDetails, secret, function (err) {
+                if (err) {
+                    this.sendAbort(session, "wamp.error.authorization_failed");
+                }
+                else {
+                    this.getRouter().getRealm(session.realmName, function (realm) {
+                        realm.joinSession(session);
+                        var details = this.getRealmDetails(session.realmName);
+                        details.authid = session.secureDetails.authid;
+                        details.authmethod = "ticket";
+                        this.sendWelcome(session, details);
+                    }.bind(this));
+                }
+            }.bind(this));
+        }
     }
 
     getRealmDetails(realmName) {
@@ -240,7 +255,20 @@ handlers[WAMP.REGISTER] = function(session, message) {
     var uri = message.shift();
 
     this.checkRealm(session, id);
-    session.realm.doRegRpc(session, { wtype:WAMP.REGISTER, id, uri, opt });
+    if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
+        this._authHandler.authorize(session, "register", uri, function (err, allowed) {
+            if (err) {
+                throw new RealmError(id, "wamp.error.authorization_failed");
+            }
+            else {
+                if (!allowed) throw new RealmError(id, "wamp.error.not_authorized");
+                session.realm.doRegRpc(session, { wtype:WAMP.REGISTER, id, uri, opt });
+            }
+        }.bind(this));
+    }
+    else {
+        session.realm.doRegRpc(session, { wtype:WAMP.REGISTER, id, uri, opt });
+    }
 };
 
 cmdAck[WAMP.REGISTER] = function (session, cmd) {
@@ -261,7 +289,20 @@ handlers[WAMP.CALL] = function(session, message) {
         cmd.opt.receive_progress = true;
     }
 
-    session.realm.doCallRpc(session, cmd);
+    if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
+        this._authHandler.authorize(session, "call", uri, function (err, allowed) {
+            if (err) {
+                throw new RealmError(id, "wamp.error.authorization_failed");
+            }
+            else {
+                if (!allowed) throw new RealmError(id, "wamp.error.not_authorized");
+                session.realm.doCallRpc(session, cmd);
+            }
+        }.bind(this));
+    }
+    else {
+        session.realm.doCallRpc(session, cmd);
+    }
 };
 
 handlers[WAMP.UNREGISTER] = function(session, message) {
@@ -269,7 +310,20 @@ handlers[WAMP.UNREGISTER] = function(session, message) {
     var unr = message.shift();
 
     this.checkRealm(session, id);
-    session.realm.doUnRegRpc(session, { wtype:WAMP.UNREGISTER, id, unr });
+    if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
+        this._authHandler.authorize(session, "unregister", session.getSub(unr), function (err, allowed) {
+            if (err) {
+                throw new RealmError(id, "wamp.error.authorization_failed");
+            }
+            else {
+                if (!allowed) throw new RealmError(id, "wamp.error.not_authorized");
+                session.realm.doUnRegRpc(session, {wtype: WAMP.UNREGISTER, id, unr});
+            }
+        }.bind(this));
+    }
+    else {
+        session.realm.doUnRegRpc(session, {wtype: WAMP.UNREGISTER, id, unr});
+    }
 };
 
 cmdAck[WAMP.UNREGISTER] = function(session, cmd) {
@@ -303,7 +357,20 @@ handlers[WAMP.SUBSCRIBE] = function(session, message) {
     var uri = message.shift();
 
     this.checkRealm(session, id);
-    session.realm.doTrace(session, { wtype:WAMP.SUBSCRIBE, id, uri, opt });
+    if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
+        this._authHandler.authorize(session, "subscribe", uri, function (err, allowed) {
+            if (err) {
+                throw new RealmError(id, "wamp.error.authorization_failed");
+            }
+            else {
+                if (!allowed) throw new RealmError(id, "wamp.error.not_authorized");
+                session.realm.doTrace(session, {wtype: WAMP.SUBSCRIBE, id, uri, opt});
+            }
+        }.bind(this));
+    }
+    else {
+        session.realm.doTrace(session, {wtype: WAMP.SUBSCRIBE, id, uri, opt});
+    }
 };
 
 cmdAck[WAMP.SUBSCRIBE] = function (session, cmd) {
@@ -315,7 +382,20 @@ handlers[WAMP.UNSUBSCRIBE] = function(session, message) {
     let unr = message.shift();
 
     this.checkRealm(session, id);
-    session.realm.doUnTrace(session, { wtype:WAMP.UNSUBSCRIBE, id, unr });
+    if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
+        this._authHandler.authorize(session, "unsubscribe", session.getTrace(unr), function (err, allowed) {
+            if (err) {
+                throw new RealmError(id, "wamp.error.authorization_failed");
+            }
+            else {
+                if (!allowed) throw new RealmError(id, "wamp.error.not_authorized");
+                session.realm.doUnTrace(session, {wtype: WAMP.UNSUBSCRIBE, id, unr});
+            }
+        }.bind(this));
+    }
+    else {
+        session.realm.doUnTrace(session, {wtype: WAMP.UNSUBSCRIBE, id, unr});
+    }
 };
 
 cmdAck[WAMP.UNSUBSCRIBE] = function (session, cmd) {
@@ -350,7 +430,20 @@ handlers[WAMP.PUBLISH] = function(session, message) {
     cmd.opt = opt;
 
     this.checkRealm(session, id);
-    session.realm.doPush(session, cmd);
+    if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
+        this._authHandler.authorize(session, "publish", uri, function (err, allowed) {
+            if (err) {
+                throw new RealmError(id, "wamp.error.authorization_failed");
+            }
+            else {
+                if (!allowed) throw new RealmError(id, "wamp.error.not_authorized");
+                session.realm.doPush(session, cmd);
+            }
+        }.bind(this));
+    }
+    else {
+        session.realm.doPush(session, cmd);
+    }
 };
 
 cmdAck[WAMP.PUBLISH] = function (session, cmd) {

--- a/lib/wamp/gate.js
+++ b/lib/wamp/gate.js
@@ -106,11 +106,13 @@ class WampHandler extends BaseGate {
                         this.sendAbort(session, "wamp.error.authorization_failed");
                     }
                     else {
+                        details.authmethod = method;
                         this.sendChallenge(session, method, extra || {});
                     }
                 }.bind(this));
             }
             else if (details.hasOwnProperty('authmethods') && details.authmethods.indexOf('ticket') >= 0) {
+                details.authmethod = 'ticket';
                 this.sendChallenge(session, 'ticket', {});
             }
             else {
@@ -141,7 +143,7 @@ class WampHandler extends BaseGate {
                         realm.joinSession(session);
                         var details = this.getRealmDetails(session.realmName);
                         details.authid = session.secureDetails.authid;
-                        details.authmethod = "ticket";
+                        details.authmethod = session.secureDetails.authmethod;
                         this.sendWelcome(session, details);
                     }.bind(this));
                 }
@@ -179,8 +181,8 @@ class WampHandler extends BaseGate {
         session.send([WAMP.WELCOME, session.sessionId, details]);
     }
 
-    sendChallenge(session, authmethod) {
-        session.send([WAMP.CHALLENGE, authmethod, {}]);
+    sendChallenge(session, authmethod, extra) {
+        session.send([WAMP.CHALLENGE, authmethod, extra || {}]);
     }
 
     sendGoodbye(session) {
@@ -311,7 +313,8 @@ handlers[WAMP.UNREGISTER] = function(session, message) {
 
     this.checkRealm(session, id);
     if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
-        this._authHandler.authorize(session, "unregister", session.getSub(unr), function (err, allowed) {
+        let s = session.getSub(unr);
+        this._authHandler.authorize(session, "unregister", s && s.msg && s.msg.uri, function (err, allowed) {
             if (err) {
                 throw new RealmError(id, "wamp.error.authorization_failed");
             }
@@ -383,7 +386,8 @@ handlers[WAMP.UNSUBSCRIBE] = function(session, message) {
 
     this.checkRealm(session, id);
     if (this.isAuthRequired() && typeof this._authHandler.authorize === "function") {
-        this._authHandler.authorize(session, "unsubscribe", session.getTrace(unr), function (err, allowed) {
+        let s = session.getTrace(unr);
+        this._authHandler.authorize(session, "unsubscribe", s && s.msg && s.msg.uri, function (err, allowed) {
             if (err) {
                 throw new RealmError(id, "wamp.error.authorization_failed");
             }


### PR DESCRIPTION
Added functionality to handle different methods of authentication. Also, added authorization per method, once a client has been authenticated. Like so:

```
var Auth = function () {
    this.handle_methods = function(realmName, secureDetails, callback) {
        secureDetails.authenticated = false;
        if (secureDetails.hasOwnProperty('authmethods')) {
            if (secureDetails.authmethods.includes('token')) callback(null, 'token', {});
            else if (secureDetails.authmethods.includes('secret')) {
                secureDetails.challenge = crypto.randomBytes(20).toString('hex');
                callback(null, 'secret', {challenge: secureDetails.challenge});
            }
            else callback(true);
        }
        else callback(true);
    };

    this.authorize = function(session, method, uri, callback) {
        if (session && session.secureDetails && session.secureDetails.authmethod && session.secureDetails.authenticated === true) {
            if (session.secureDetails.authmethod === "secret") callback(null, true);
            else if (session.secureDetails.authmethod === "token" && session.secureDetails.token) {
                jwt.verify(session.secureDetails.token, publicKey, {algorithm: 'RS256'}, (err, decoded) => {
                    if (err) callback(err);
                    else {
                        if (method === "unsubscribe") method = "subscribe";
                        if (method === "unregister") method = "register";
                        if (decoded.permissions.includes("wamp_" + method + "_" + uri)) callback(null, true);
                        else callback(null, false);
                    }
                });
            }
        }
        else callback(null, false);
    };

    this.authenticate = function (realmName, secureDetails, secret, callback) {
        secureDetails.authenticated = false;
        if (secureDetails.authmethod === "secret") {
            let verifier = crypto.createVerify('sha256');
            verifier.update(secureDetails.challenge);
            if(verifier.verify(publicKey, secret,'base64')) {
                secureDetails.authenticated = true;
                callback();
            }
            else callback(true);
        }
        else if (secureDetails.authmethod === "token") {
            jwt.verify(secret, publicKey, {algorithm: 'RS256'}, (err, decoded) => {
                if (err) callback(err);
                else {
                    if (decoded.permissions.includes("ws_connection")) {
                        secureDetails.token = secret;
                        secureDetails.authenticated = true;
                        callback();
                    }
                    else callback(true);
                }
            });
        }
        else callback(true);
    };
};

```